### PR TITLE
Fix: Allowing Update() to take multiple GTIDs

### DIFF
--- a/vendor/github.com/siddontang/go-mysql/mysql/mysql_gtid.go
+++ b/vendor/github.com/siddontang/go-mysql/mysql/mysql_gtid.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/siddontang/go/hack"
 )
 
@@ -353,13 +353,13 @@ func (s *MysqlGTIDSet) AddSet(set *UUIDSet) {
 }
 
 func (s *MysqlGTIDSet) Update(GTIDStr string) error {
-	uuidSet, err := ParseUUIDSet(GTIDStr)
+	gtidSet, err := ParseMysqlGTIDSet(GTIDStr)
 	if err != nil {
 		return err
 	}
-
-	s.AddSet(uuidSet)
-
+	for _, uuidSet := range gtidSet.(*MysqlGTIDSet).Sets {
+		s.AddSet(uuidSet)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This patch is a port of [an upstream fix](https://github.com/go-mysql-org/go-mysql/commit/c4c58547fff31a36c5ba4a557559e247a32084f3) which resolves an issue where kingbus may crash if multiple GTIDs are present (eg. if the master server is changed)